### PR TITLE
Correct colored diff output

### DIFF
--- a/tui/svncmds.go
+++ b/tui/svncmds.go
@@ -66,7 +66,7 @@ func (t *Tui) SvnDiff(repos string, path string, rev string) string {
 	url := t.config.Repos[repos].Url + path
 	rev = strings.TrimPrefix(rev, "r")
 	rev_opt := "-c" + rev
-	cmd := exec.Command("svn", "diff", rev_opt, url)
+	cmd := exec.Command("svn", "diff", "--internal-diff", rev_opt, url)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout


### PR DESCRIPTION
On linux if [colordiff](https://www.colordiff.org/) or something similar is installed the diff output is broken, as the `svn diff` output  already contains the color encoding. Therefor the color output does not work, since the line do not start with the expected symbols.

To fix this we simply force `svn diff` to use the internal diff instead a possible external tool.