### PR TITLE
Allow moving with cursor keys

### DIFF
--- a/tui/tui_diff.go
+++ b/tui/tui_diff.go
@@ -58,6 +58,18 @@ func (t *Tui) NewTuiDiff(repos string, path string, rev string) {
 				t.BackScreen()
 				return nil
 			}
+		case tcell.KeyUp:
+			row, _ := main.GetSelection()
+			row--
+			main.Select(row, 0)
+			return nil
+		case tcell.KeyDown:
+			row, _ := main.GetSelection()
+			if row < main.GetRowCount()-1 {
+				row++
+			}
+			main.Select(row, 0)
+			return nil
 		}
 		return event
 	})

--- a/tui/tui_log.go
+++ b/tui/tui_log.go
@@ -77,6 +77,18 @@ func (t *Tui) NewTuiLog(repos string, path string) {
 			rev = re1.ReplaceAllString(rev, "")
 			t.ChangeScreen(repos, "rev:"+path+":"+rev)
 			return nil
+		case tcell.KeyDown:
+			row, _ := main.GetSelection()
+			if row < main.GetRowCount()-1 {
+				row++
+			}
+			main.Select(row, 0)
+			return nil
+		case tcell.KeyUp:
+			row, _ := main.GetSelection()
+			row--
+			main.Select(row, 0)
+			return nil
 		case tcell.KeyRune:
 			switch event.Rune() {
 			case 'k':

--- a/tui/tui_rev.go
+++ b/tui/tui_rev.go
@@ -78,6 +78,18 @@ func (t *Tui) NewTuiRev(repos string, path string, rev string) {
 				t.ChangeScreen(repos, change_screen)
 			}
 			return nil
+		case tcell.KeyDown:
+			row, _ := main.GetSelection()
+			if row < main.GetRowCount()-1 {
+				row++
+			}
+			main.Select(row, 0)
+			return nil
+		case tcell.KeyUp:
+			row, _ := main.GetSelection()
+			row--
+			main.Select(row, 0)
+			return nil
 		case tcell.KeyRune:
 			switch event.Rune() {
 			case 'k':

--- a/tui/tui_root.go
+++ b/tui/tui_root.go
@@ -51,6 +51,18 @@ func (t *Tui) NewTuiRoot() {
 				t.BackScreen()
 				return nil
 			}
+		case tcell.KeyDown:
+			row, _ := main.GetSelection()
+			if row < main.GetRowCount()-1 {
+				row++
+			}
+			main.Select(row, 0)
+			return nil
+		case tcell.KeyUp:
+			row, _ := main.GetSelection()
+			row--
+			main.Select(row, 0)
+			return nil
 		}
 		return event
 	})

--- a/tui/tui_tree.go
+++ b/tui/tui_tree.go
@@ -128,6 +128,18 @@ func (t *Tui) NewTuiTree(repos string, path string) {
 				t.ChangeScreen(repos, "tree:"+changedpath)
 			}
 			return nil
+		case tcell.KeyDown:
+			row, _ := main.GetSelection()
+			if row < main.GetRowCount()-1 {
+				row++
+			}
+			main.Select(row, 0)
+			return nil
+		case tcell.KeyUp:
+			row, _ := main.GetSelection()
+			row--
+			main.Select(row, 0)
+			return nil
 		case tcell.KeyRune:
 			switch event.Rune() {
 			case 'k':


### PR DESCRIPTION
Although moving with `j` and `k` is perfectly fine, it is somewhat unintuitive for "younger" users which don't know `vi` and it's control schema.

Due to limited [go](https://go.dev/) knowledge, simply duplicate the code used for `j`,`k` keys also on cursor `up`, `down` events.